### PR TITLE
added /etc/hosts to logs

### DIFF
--- a/devstack_vm/bin/run_devstack.sh
+++ b/devstack_vm/bin/run_devstack.sh
@@ -38,6 +38,8 @@ PBR_LOC="/opt/stack/pbr"
 # Clean devstack logs
 sudo rm -f "$DEVSTACK_LOGS/*"
 sudo rm -rf "$PBR_LOC"
+cp /etc/hosts $DEVSTACK_LOGS/hosts.txt
+
 
 MYIP=$(/sbin/ifconfig eth0 2>/dev/null| grep "inet addr:" 2>/dev/null| sed 's/.*inet addr://g;s/ .*//g' 2>/dev/null)
 


### PR DESCRIPTION
the cp looks like this because it seems that the devstack logs folder never gets actually deleted, only the contained files do
